### PR TITLE
Implements configuration without settings

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,16 +6,17 @@ python:
   - '3.6'
 
 env:
-  - DJANGO=true
-  - SIMPLE_SETTINGS=true
+  - USE_DJANGO=true
+  - USE_SIMPLE_SETTINGS=true
+  - NO_THIRD_PARTY_LIBS=true
 
 cache:
   directories:
     - "$HOME/.cache/pip"
 
 install:
-  - if [ ${DJANGO} ]; then pip install Django>=1.8; fi
-  - if [ ${SIMPLE_SETTINGS} ]; then pip install simple_settings; fi
+  - if [ ${USE_DJANGO} ]; then pip install Django>=1.8; fi
+  - if [ ${USE_SIMPLE_SETTINGS} ]; then pip install simple_settings; fi
   - pip install -r requirements-dev.txt
 
 before_install:

--- a/README.rst
+++ b/README.rst
@@ -18,6 +18,7 @@ Setup
 
     pip install ramos
 
+
 Development setup
 -----------------
 
@@ -25,17 +26,27 @@ Development setup
 
     make install
 
-Requirements
-------------
-
-Ramos uses `Django`_ or `Simple Settings`_ to get backends
-configurations.
 
 Usage
 -----
 
-Settings
-~~~~~~~~
+.. code:: python
+
+    import ramos
+
+    ramos.configure(pools={
+        'backend_type': [
+            'path.to.backend_a',
+            'path.to.backend_b',
+        ]
+    })
+
+
+Integrations
+~~~~~~~~~~~~
+
+Ramos can uses `Django`_ or `Simple Settings`_ to get backends
+configurations if set settings.POOL_OF_RAMOS:
 
 .. code:: python
 
@@ -45,6 +56,7 @@ Settings
             'path.to.backend_b',
         ]
     }
+
 
 Backend Implementations
 ~~~~~~~~~~~~~~~~~~~~~~~
@@ -64,6 +76,7 @@ Backend Implementations
         id = 'backend_b'
         def say(self):
             return 'B'
+
 
 Backend Pool
 ~~~~~~~~~~~~

--- a/ramos/__init__.py
+++ b/ramos/__init__.py
@@ -1,2 +1,7 @@
 # -*- coding: utf-8 -*-
+
+from .compat import configure
+
 __version__ = '1.0.0'
+
+__all__ = ('configure',)

--- a/ramos/compat.py
+++ b/ramos/compat.py
@@ -1,7 +1,27 @@
+import threading
+
+_tls = threading.local()
+
+_tls.INSTALLED_POOLS = {}
+
+
+def configure(pools):
+    _tls.INSTALLED_POOLS = dict(pools)
+
+
+def get_installed_pools():
+    return _tls.INSTALLED_POOLS
+
+
 try:
-    from django.conf import settings  # noqa
+    from django.conf import settings
+    configure(pools=settings.POOL_OF_RAMOS)
 except ImportError:
-    from simple_settings import settings  # noqa
+    try:
+        from simple_settings import settings
+        configure(pools=settings.POOL_OF_RAMOS)
+    except ImportError:
+        pass
 
 
 try:

--- a/ramos/exceptions.py
+++ b/ramos/exceptions.py
@@ -2,7 +2,7 @@
 class InvalidBackendError(Exception):
     """
     InvalidBackendError is raised when instances of BackendPool
-    can't get a backend implmentation
+    can't get a backend implementation
     """
 
     def __init__(self, backend_type, backend_id, available_backends):

--- a/ramos/pool.py
+++ b/ramos/pool.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
-from .compat import ImproperlyConfigured, import_string, settings
+
+from .compat import ImproperlyConfigured, get_installed_pools, import_string
 from .exceptions import InvalidBackendError
 
 
@@ -13,7 +14,7 @@ class BackendPool(object):
     @classmethod
     def get(cls, backend_id):
         """
-        Return an instace of backend type
+        Return an instance of backend type
         """
 
         for backend_class in cls._get_backends_classes():
@@ -23,7 +24,7 @@ class BackendPool(object):
         raise InvalidBackendError(
             cls.backend_type,
             backend_id,
-            settings.POOL_OF_RAMOS[cls.backend_type]
+            get_installed_pools()[cls.backend_type]
         )
 
     @classmethod
@@ -40,7 +41,7 @@ class BackendPool(object):
     @classmethod
     def _get_backends_classes(cls):
         try:
-            backend_list = settings.POOL_OF_RAMOS[cls.backend_type]
+            backend_list = get_installed_pools()[cls.backend_type]
         except KeyError:
             raise ImproperlyConfigured(
                 u'Backend type "{}" config not found'.format(cls.backend_type)

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -4,3 +4,4 @@ flake8==3.5.0
 isort==4.3.4
 pytest-cov==2.6.0
 pytest==3.8.2
+mock==2.0.0

--- a/tests/test_compat.py
+++ b/tests/test_compat.py
@@ -1,7 +1,22 @@
 # -*- coding: utf-8 -*-
 import pytest
+from mock import Mock, patch
 
-from ramos.compat import import_string
+from ramos.compat import configure, get_installed_pools, import_string
+
+try:
+    from importlib import reload
+except ImportError:
+    pass
+
+
+def assert_pools_is_equals_settings(pools, modules):
+    with patch.dict('sys.modules', modules):
+        from ramos import compat
+
+        reload(compat)
+
+        assert get_installed_pools() == pools
 
 
 class TestImportString(object):
@@ -21,3 +36,58 @@ class TestImportString(object):
         cls = import_string('ramos.compat.import_string')
 
         assert cls == import_string
+
+
+class TestConfiguration:
+
+    def test_should_configure_pools(self):
+        pools = {
+            'backend_a': [
+                'path.to.backend'
+            ],
+            'backend_b': [
+                'path.to.backend'
+            ]
+        }
+
+        configure(pools=pools)
+
+        assert get_installed_pools() == pools
+
+    def test_should_configure_pools_from_django_settings(self):
+        pools = {
+            'backend-from-django-settings': [
+                'path.to.backend'
+            ]
+        }
+
+        django = Mock()
+        django.conf.settings.POOL_OF_RAMOS = pools
+
+        assert_pools_is_equals_settings(
+            pools=pools,
+            modules={
+                'django': django,
+                'django.conf': django.conf,
+                'simple_settings': None
+            }
+        )
+
+    def test_should_configure_pools_from_simple_settings(self):
+        pools = {
+            'backend-from-simple-settings': [
+                'path.to.backend'
+            ]
+        }
+
+        simple_settings = Mock()
+        simple_settings.settings.POOL_OF_RAMOS = pools
+
+        assert_pools_is_equals_settings(
+            pools=pools,
+            modules={
+                'django': None,
+                'django.conf': None,
+                'simple_settings': simple_settings
+            }
+        )

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -1,0 +1,23 @@
+from ramos.compat import get_installed_pools
+
+try:
+    from importlib import reload
+except ImportError:
+    pass
+
+
+def test_should_configure_if_settings(settings):
+    settings.POOL_OF_RAMOS = {
+        'backend_a': [
+            'path.to.backend'
+        ],
+        'backend_b': [
+            'path.to.backend'
+        ],
+    }
+
+    from ramos import compat
+
+    reload(compat)
+
+    assert get_installed_pools() == settings.POOL_OF_RAMOS

--- a/tests/test_pool.py
+++ b/tests/test_pool.py
@@ -1,7 +1,8 @@
 # -*- coding: utf-8 -*-
 import pytest
 
-from ramos.compat import ImproperlyConfigured, settings
+from ramos import configure
+from ramos.compat import ImproperlyConfigured
 from ramos.exceptions import InvalidBackendError
 from ramos.mixins import ThreadSafeCreateMixin
 from ramos.pool import BackendPool
@@ -18,7 +19,7 @@ class FakeXYZBackend(ThreadSafeCreateMixin):
 class TestBackendPool(object):
 
     def test_get_backends_should_return_all_backends_instances(self):
-        settings.POOL_OF_RAMOS = {
+        configure(pools={
             BackendPool.backend_type: (
                 u'{module}.{cls}'.format(
                     module=__name__,
@@ -29,7 +30,7 @@ class TestBackendPool(object):
                     cls=FakeABCBackend.__name__
                 ),
             )
-        }
+        })
 
         backends = BackendPool.all()
 
@@ -37,20 +38,20 @@ class TestBackendPool(object):
         assert isinstance(backends[1], FakeABCBackend)
 
     def test_get_backends_without_config_should_raise(self):
-        settings.POOL_OF_RAMOS = {}
+        configure(pools={})
 
         with pytest.raises(ImproperlyConfigured):
             BackendPool.all()
 
     def test_get_backends_with_zero_backends_should_return_empty_list(self):
-        settings.POOL_OF_RAMOS = {
+        configure(pools={
             BackendPool.backend_type: {}
-        }
+        })
 
         assert BackendPool.all() == []
 
     def test_get_should_return_the_backend_instance(self):
-        settings.POOL_OF_RAMOS = {
+        configure(pools={
             BackendPool.backend_type: (
                 u'{module}.{cls}'.format(
                     module=__name__,
@@ -61,14 +62,14 @@ class TestBackendPool(object):
                     cls=FakeABCBackend.__name__
                 ),
             )
-        }
+        })
 
         backend = BackendPool.get('fake_abc')
 
         assert isinstance(backend, FakeABCBackend)
 
-    def test_get_with_inexisting_backend_should_raise(self):
-        settings.POOL_OF_RAMOS = {
+    def test_get_with_nonexistent_backend_should_raise(self):
+        configure(pools={
             BackendPool.backend_type: (
                 u'{module}.{cls}'.format(
                     module=__name__,
@@ -79,7 +80,7 @@ class TestBackendPool(object):
                     cls=FakeABCBackend.__name__
                 ),
             )
-        }
+        })
 
         with pytest.raises(InvalidBackendError):
             BackendPool.get('fake_fake')


### PR DESCRIPTION
Implemented `ramos.configure()` and `ramos.get_installed_pools()` to use without settings. The support for django and simple-settings is maintained. 