### PR TITLE
Add DefaultBackendMixin

### DIFF
--- a/docs/mixins.md
+++ b/docs/mixins.md
@@ -1,5 +1,5 @@
-Mixins
-======
+Backend Mixins
+==============
 
 As every backend needs a way to create itself, the `ramos.mixins` module
 provides mixin classes for this task which might be repetitive otherwise.
@@ -40,3 +40,22 @@ ThreadSafeCreateMixin
 
 The inherited class will return a new instance of itself in every call of
 `create`.
+
+Pool Mixins
+===========
+
+DefaultBackendMixin
+-------------------
+
+The inherited class will have the option to return a default backend based on
+the `SETTINGS_KEY` value that will exist in your `settings`.
+
+```python
+from ramos.pool import BackendPool
+
+class MyBackendPool(DefaultBackendMixin, BackendPool):
+    SETTINGS_KEY = 'DEFAULT_BACKEND_ID'
+
+backend = MyBackendPool.get_default()
+assert backend.id == 'DEFAULT_BACKEND_ID'
+```

--- a/ramos/compat.py
+++ b/ramos/compat.py
@@ -12,7 +12,7 @@ def configure(pools):
 def get_installed_pools():
     return _tls.INSTALLED_POOLS
 
-
+settings = None  # noqa
 try:
     from django.conf import settings
     configure(pools=settings.POOL_OF_RAMOS)

--- a/ramos/mixins.py
+++ b/ramos/mixins.py
@@ -1,5 +1,7 @@
 # -*- coding: utf-8 -*-
 
+from .compat import settings
+
 
 class ThreadSafeCreateMixin(object):
     """
@@ -32,3 +34,27 @@ class SingletonCreateMixin(object):
             cls._instances[cls] = cls()
 
         return cls._instances[cls]
+
+
+class DefaultBackendMixin(object):
+    """
+    Creates the method 'get_default' that will return the backend with the
+    `SETTINGS_KEY` key value
+    """
+    SETTINGS_KEY = None
+
+    @classmethod
+    def get_default(cls):
+        if cls.SETTINGS_KEY is None:
+            raise AttributeError(
+                'You must set a `SETTINGS_KEY` to the Pool.'
+            )
+
+        try:
+            backend_id = getattr(settings, cls.SETTINGS_KEY)
+        except AttributeError:
+            raise AttributeError(
+                'Key {key} not found on settings.'.format(key=cls.SETTINGS_KEY)
+            )
+
+        return cls.get(backend_id=backend_id)


### PR DESCRIPTION
I've seen in a lot of projects the user of a `get_default` method in several backend pools.

The idea is that you can set a single var with the name of the settings variable that corresponds to the default backend id.


