### PR TITLE
Using thread locals only for ramos without simple-settings or django

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -8,7 +8,7 @@ Ramos
     :target: https://codecov.io/gh/luizalabs/ramos
 
 
-Generic backend pool for Django
+Generic backend pool
 
 
 Setup

--- a/conftest.py
+++ b/conftest.py
@@ -20,7 +20,10 @@ def reset_pools():
 @pytest.fixture(autouse=True)
 def reset_settings():
     if _SETTINGS:
-        _SETTINGS.POOL_OF_RAMOS = POOL_OF_RAMOS
+        try:
+            _SETTINGS.configure(POOL_OF_RAMOS=POOL_OF_RAMOS)
+        except RuntimeError:
+            _SETTINGS.POOL_OF_RAMOS = POOL_OF_RAMOS
 
 
 @pytest.fixture

--- a/ramos/compat.py
+++ b/ramos/compat.py
@@ -1,27 +1,25 @@
 import threading
 
-_tls = threading.local()
-
-_tls.INSTALLED_POOLS = {}
-
-
-def configure(pools):
-    _tls.INSTALLED_POOLS = dict(pools)
-
-
-def get_installed_pools():
-    return _tls.INSTALLED_POOLS
-
 settings = None  # noqa
 try:
     from django.conf import settings
-    configure(pools=settings.POOL_OF_RAMOS)
 except ImportError:
     try:
         from simple_settings import settings
-        configure(pools=settings.POOL_OF_RAMOS)
     except ImportError:
-        pass
+        settings = threading.local()
+        settings.POOL_OF_RAMOS = {}
+
+
+def get_installed_pools():
+    return settings.POOL_OF_RAMOS
+
+
+def configure(pools):
+    try:
+        settings.configure(POOL_OF_RAMOS=pools)
+    except (AttributeError, RuntimeError):
+        settings.POOL_OF_RAMOS = dict(pools)
 
 
 try:

--- a/tests/test_compat.py
+++ b/tests/test_compat.py
@@ -1,22 +1,7 @@
 # -*- coding: utf-8 -*-
 import pytest
-from mock import Mock, patch
 
 from ramos.compat import configure, get_installed_pools, import_string
-
-try:
-    from importlib import reload
-except ImportError:
-    pass
-
-
-def assert_pools_is_equals_settings(pools, modules):
-    with patch.dict('sys.modules', modules):
-        from ramos import compat
-
-        reload(compat)
-
-        assert get_installed_pools() == pools
 
 
 class TestImportString(object):
@@ -53,41 +38,3 @@ class TestConfiguration:
         configure(pools=pools)
 
         assert get_installed_pools() == pools
-
-    def test_should_configure_pools_from_django_settings(self):
-        pools = {
-            'backend-from-django-settings': [
-                'path.to.backend'
-            ]
-        }
-
-        django = Mock()
-        django.conf.settings.POOL_OF_RAMOS = pools
-
-        assert_pools_is_equals_settings(
-            pools=pools,
-            modules={
-                'django': django,
-                'django.conf': django.conf,
-                'simple_settings': None
-            }
-        )
-
-    def test_should_configure_pools_from_simple_settings(self):
-        pools = {
-            'backend-from-simple-settings': [
-                'path.to.backend'
-            ]
-        }
-
-        simple_settings = Mock()
-        simple_settings.settings.POOL_OF_RAMOS = pools
-
-        assert_pools_is_equals_settings(
-            pools=pools,
-            modules={
-                'django': None,
-                'django.conf': None,
-                'simple_settings': simple_settings
-            }
-        )


### PR DESCRIPTION
This change will solve an issue with Django tests when you change the value
of `POOL_OF_RAMOS` settings and that change does not affect the BackendPool
for example:

```python
# settings.POOL_OF_RAMOS['backends'] = []

def test_should_check_some_value(settings):
    settings.POOL_OF_RAMOS['backends'] = ['some', 'backends']
    assert len(BackendPool.all()) == 2

AssertionError
```

Also, I removed tests that change namespaces and modules already loaded (that cause side effects)