### PR TITLE
Setup travis build to upload artifacts only once

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -38,3 +38,4 @@ deploy:
   on:
     tags: true
     repo: luizalabs/ramos
+skip_existing: true


### PR DESCRIPTION
- add `skip_existing` for not to generate duplicate tags on deploy
