### PR TITLE
Fix minor typos in the docs

### DIFF
--- a/docs/mixins.md
+++ b/docs/mixins.md
@@ -33,7 +33,7 @@ assert backend is other  # True
 SingletonCreateMixin
 --------------------
 
-Then inherited class will return always the same instance of the backend in
+The inherited class will return always the same instance of the backend in
 every call of `create`.
 
 

--- a/docs/settings.md
+++ b/docs/settings.md
@@ -35,7 +35,7 @@ Django Settings
 ---------------
 
 If you are using [Django][https://www.djangoproject.com/], you can use a
-variable `POLL_OF_RAMOS` in your settings file instead of `ramos.configure`.
+variable `POOL_OF_RAMOS` in your settings file instead of `ramos.configure`.
 
 #### example
 ```python
@@ -53,4 +53,4 @@ Simple Settings
 ---------------
 
 **Ramos** also supports [Simple Settings](https://github.com/drgarcia1986/simple-settings)
-which can setup a `POLL_OF_RAMOS` variable, like Django's settings.
+which can setup a `POOL_OF_RAMOS` variable, like Django's settings.


### PR DESCRIPTION
I found a few very minor typos on the documentation.

Other than that it's really well written and easy to understand, congrats.