### PR TITLE
Add arguments to create singleton instances

### DIFF
--- a/docs/mixins.md
+++ b/docs/mixins.md
@@ -36,6 +36,12 @@ SingletonCreateMixin
 The inherited class will return always the same instance of the backend in
 every call of `create`.
 
+**caveat**: When `SingletonCreateMixin` is used with args and kwargs,
+every backend of the same type should use it as well, so that the backend pool
+can create every backend instance using the exact same parameters. The args and kwargs
+will be concatenated with class path and qualifier name to generate a unique identifier
+to be used to find the instances previously created.
+
 
 ThreadSafeCreateMixin
 ---------------------

--- a/ramos/mixins.py
+++ b/ramos/mixins.py
@@ -24,14 +24,23 @@ class SingletonCreateMixin:
     _instances = {}
 
     @classmethod
-    def create(cls):
+    def _get_instance_key(cls, *args, **kwargs):
+        class_path = f'{cls.__module__}.{cls.__qualname__}'
+        kwargs_tuple = tuple(sorted(kwargs.items()))
+
+        return f'{class_path}|{hash(args)}|{hash(kwargs_tuple)}'
+
+    @classmethod
+    def create(cls, *args, **kwargs):
         """
         Return always the same instance of the backend class
         """
-        if cls not in cls._instances:
-            cls._instances[cls] = cls()
+        key = cls._get_instance_key(*args, **kwargs)
 
-        return cls._instances[cls]
+        if key not in cls._instances:
+            cls._instances[key] = cls(*args, **kwargs)
+
+        return cls._instances[key]
 
 
 class DefaultBackendMixin:

--- a/tests/test_mixins.py
+++ b/tests/test_mixins.py
@@ -9,6 +9,13 @@ from ramos.mixins import (
 )
 
 
+class SingletonClass(SingletonCreateMixin):
+    def __init__(self, arg1, arg2, arg3):
+        self.arg1 = arg1
+        self.arg2 = arg2
+        self.arg3 = arg3
+
+
 class SingletonDerived(SingletonCreateMixin):
     pass
 
@@ -45,6 +52,31 @@ class TestSingletonCreateMixin:
         assert (
             AnotherSingletonDerived.create() is not SingletonDerived.create()
         )
+
+    def test_create_should_pass_args_to_create_a_new_singleton_instance(self):
+        instance = SingletonClass.create(1, 2, arg3=3)
+
+        assert instance.arg1 == 1
+        assert instance.arg2 == 2
+        assert instance.arg3 == 3
+
+    def test_create_should_return_same_instance_for_equal_args(self):
+        instance_a = SingletonClass.create(1, 2, arg3=3)
+        instance_b = SingletonClass.create(1, 2, arg3=3)
+
+        assert instance_a is instance_b
+
+    def test_create_should_return_new_instance_for_different_args(self):
+        instance_a = SingletonClass.create(1, 2, arg3=3)
+        instance_b = SingletonClass.create(2, 1, arg3=3)
+
+        assert instance_a is not instance_b
+
+    def test_create_should_return_same_instance_for_diff_kwargs_order(self):
+        instance_a = SingletonClass.create(1, arg2=2, arg3=3)
+        instance_b = SingletonClass.create(1, arg3=3, arg2=2)
+
+        assert instance_a is instance_b
 
 
 class TestThreadSafeCreateMixin:


### PR DESCRIPTION
Fix create method of `SingletonCreateMixin` to receive initialization arguments.